### PR TITLE
Display the correct revert reason in cli

### DIFF
--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -157,8 +157,8 @@ module.exports = function (opts, cb) {
     var gasProvided = new BN(block.transactions[0].gas)
 
     var callResultObject = query.getCallresult()
-    var returnData = callResultObject.getReturndata()
-    returnData = returnData.length ? ethUtil.bufferToHex(Buffer.from(returnData)) : returnData
+    var rawReturnData = Buffer.from(callResultObject.getReturndata())
+    var returnData = rawReturnData.length ? ethUtil.bufferToHex(rawReturnData) : rawReturnData
     var returnCode = callResultObject.getReturncode()
     var gasRemaining = new BN(callResultObject.getGasremaining())
     var gasRefund = new BN(callResultObject.getGasrefund())
@@ -176,7 +176,7 @@ module.exports = function (opts, cb) {
         blockchain: self.blockchain,
         stateManager: stateManager,
         storageReader: storageReader,
-        returnValue: returnData,
+        returnValue: error ? rawReturnData : returnData,
         stopped: false,
         vmError: false,
         programCounter: opts.pc | 0,


### PR DESCRIPTION
In case of `revert` the `returnData` may contain user defined data used by `ganache-core` to display the reason of the `revert`. 

To fix this issue, we send the unprocessed `returnData` if an error has been found.