### PR TITLE
Send the corect amount of ether to kevm-vm

### DIFF
--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -60,7 +60,6 @@ module.exports = function (opts, cb) {
   // var salt = opts.salt || null
   var storageReader = opts.storageReader || new StorageReader(stateManager)
   var results = {}
-  txValue = new BN(txValue)
   var client = new net.Socket()
   const kevmHost = '127.0.0.1'
   const kevmPort = 8080
@@ -410,7 +409,7 @@ module.exports = function (opts, cb) {
       callCtx.setRecipientaddr(toAddress)
     }
     callCtx.setInputdata(txData)
-    callCtx.setCallvalue(new Uint8Array(txValue.words))
+    callCtx.setCallvalue(new Uint8Array(txValue))
     callCtx.setGasprice(gasPrice)
     callCtx.setGasprovided(block.transactions[0].gas)
     callCtx.setBlockheader(blockHeader)


### PR DESCRIPTION
The incorrect `txValue` was sent to `kevm-vm` because of a conversion to `BN`. This would cause an incorrect amount of ether to be sent between accounts.